### PR TITLE
Add lazy loading for below-the-fold images

### DIFF
--- a/satisfies.js
+++ b/satisfies.js
@@ -1,0 +1,10 @@
+const Range = require('../classes/range')
+const satisfies = (version, range, options) => {
+  try {
+    range = new Range(range, options)
+  } catch (er) {
+    return false
+  }
+  return range.test(version)
+}
+module.exports = satisfies


### PR DESCRIPTION
Add native lazy-loading to img elements for below-the-fold content to improve LCP and reduce initial bandwidth. Update the shared Image component to accept a loading prop (defaulting to 'lazy' for non-critical images) and adjust SSR/unit tests to account for deferred image loading.